### PR TITLE
Fix large param types (long / double) in parameters. Closes #16

### DIFF
--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/CompilerUtils.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/CompilerUtils.java
@@ -70,7 +70,7 @@ public class CompilerUtils {
 			FunctionParameter parameter = header.parameters[i];
 			String parameterType = context.getDescriptor(parameter.type);
 			module.setParameterInfo(parameter, new JavaParameterInfo(index, parameterType));
-			index++;
+			index += isLarge(parameter.type) ? 2 : 1;
 		}
 	}
 
@@ -104,7 +104,7 @@ public class CompilerUtils {
 			FunctionParameter parameter = header.parameters[i];
 			String parameterType = context.getDescriptor(parameter.type);
 			module.setParameterInfo(parameter, new JavaParameterInfo(index, parameterType));
-			index++;
+			index += isLarge(parameter.type) ? 2 : 1;
 		}
 		/*
 		int index = header.getNumberOfTypeParameters();


### PR DESCRIPTION
All tests still pass (although we should probably add some tests for this specific case) and the script provided in the issue now works (also tested using longs in the script and it still works)