### PR TITLE
Fix creating arrays of functional interfaces. Fixes #11

### DIFF
--- a/JavaShared/src/main/java/org/openzen/zenscript/javashared/JavaTypeDescriptorVisitor.java
+++ b/JavaShared/src/main/java/org/openzen/zenscript/javashared/JavaTypeDescriptorVisitor.java
@@ -3,6 +3,7 @@ package org.openzen.zenscript.javashared;
 import org.openzen.zenscript.codemodel.generic.ParameterTypeBound;
 import org.openzen.zenscript.codemodel.generic.TypeParameterBound;
 import org.openzen.zenscript.codemodel.type.*;
+import org.openzen.zenscript.javashared.types.JavaFunctionalInterfaceTypeID;
 
 import java.util.Arrays;
 
@@ -123,7 +124,11 @@ public class JavaTypeDescriptorVisitor implements TypeVisitor<String> {
 
 	@Override
 	public String visitFunction(FunctionTypeID function) {
-		return "L" + this.context.getFunction(function).getCls().internalName + ";";
+		if (function instanceof JavaFunctionalInterfaceTypeID) {
+			return "L" + ((JavaFunctionalInterfaceTypeID) function).method.cls.internalName + ";";
+		} else {
+			return "L" + this.context.getFunction(function).getCls().internalName + ";";
+		}
 	}
 
 	@Override

--- a/Parser/src/main/java/org/openzen/zenscript/parser/expression/ParsedExpressionFunction.java
+++ b/Parser/src/main/java/org/openzen/zenscript/parser/expression/ParsedExpressionFunction.java
@@ -39,6 +39,7 @@ public class ParsedExpressionFunction extends ParsedExpression {
 	public IPartialExpression compile(ExpressionScope scope) throws CompileException {
 		FunctionHeader definedHeader = header.compile(scope);
 		FunctionHeader header = definedHeader;
+		FunctionTypeID type = null;
 		for (TypeID hint : scope.hints) {
 			if (hint.getNormalized() instanceof FunctionTypeID) {
 				FunctionTypeID functionHint = (FunctionTypeID) hint.getNormalized();
@@ -47,6 +48,7 @@ public class ParsedExpressionFunction extends ParsedExpression {
 						return new InvalidExpression(position, hint, CompileExceptionCode.MULTIPLE_MATCHING_HINTS, "Ambiguity trying to resolve function types, can't decide for the type");
 
 					header = functionHint.header.forLambda(definedHeader);
+					type = functionHint;
 				}
 			}
 		}
@@ -94,8 +96,9 @@ public class ParsedExpressionFunction extends ParsedExpression {
 		if (thatOtherHeader.getReturnType() == BasicTypeID.UNDETERMINED) {
 			thatOtherHeader.setReturnType(header.getReturnType());
 		}
-		TypeID functionType = scope.getTypeRegistry().getFunction(thatOtherHeader);
-		return new FunctionExpression(position, functionType, closure, header, statements);
+		if (type == null)
+			type = scope.getTypeRegistry().getFunction(thatOtherHeader);
+		return new FunctionExpression(position, type, closure, header, statements);
 	}
 
 	@Override

--- a/ScriptingExample/src/test/java/org/openzen/zenscript/scriptingexample/tests/actual_test/java_native/FunctionalInterfaceArray.java
+++ b/ScriptingExample/src/test/java/org/openzen/zenscript/scriptingexample/tests/actual_test/java_native/FunctionalInterfaceArray.java
@@ -1,0 +1,39 @@
+package org.openzen.zenscript.scriptingexample.tests.actual_test.java_native;
+
+import org.junit.jupiter.api.Test;
+import org.openzen.zencode.java.ZenCodeGlobals;
+import org.openzen.zencode.java.ZenCodeType;
+import org.openzen.zenscript.scriptingexample.tests.helpers.ZenCodeTest;
+
+import java.util.List;
+
+public class FunctionalInterfaceArray extends ZenCodeTest {
+
+	@Override
+	public List<Class<?>> getRequiredClasses() {
+		final List<Class<?>> requiredClasses = super.getRequiredClasses();
+		requiredClasses.add(TestClass.class);
+		return requiredClasses;
+	}
+
+	@Test
+	public void testFunctionalInterfaceArray() {
+		addScript("execute([() => println('A'), () => println('B')]);");
+		executeEngine();
+
+		logger.assertNoErrors();
+		logger.assertNoWarnings();
+		logger.assertPrintOutputSize(2);
+		logger.assertPrintOutput(0, "A");
+		logger.assertPrintOutput(1, "B");
+	}
+
+	@ZenCodeType.Name("test_module.java_native.TestClass")
+	public static final class TestClass {
+		@ZenCodeGlobals.Global
+		public static void execute(Runnable[] code) {
+			for (Runnable r : code)
+				r.run();
+		}
+	}
+}


### PR DESCRIPTION
Functional interface arrays were not being created properly. Also, type inference didn't propagate properly.