### PR TITLE
Attempt at fixing downcasting / implicit casting for Definitions

### DIFF
--- a/CodeFormatter/src/main/java/org/openzen/zenscript/formatter/ExpressionFormatter.java
+++ b/CodeFormatter/src/main/java/org/openzen/zenscript/formatter/ExpressionFormatter.java
@@ -600,6 +600,12 @@ public class ExpressionFormatter implements ExpressionVisitor<ExpressionString> 
 	}
 
 	@Override
+	public ExpressionString visitSubtypeCast(SubtypeCastExpression expression) {
+
+		return expression.value.accept(this);
+	}
+
+	@Override
 	public ExpressionString visitThis(ThisExpression expression) {
 		return new ExpressionString("this", ZenScriptOperator.PRIMARY);
 	}

--- a/CodeFormatter/src/main/java/org/openzen/zenscript/formatter/ExpressionFormatter.java
+++ b/CodeFormatter/src/main/java/org/openzen/zenscript/formatter/ExpressionFormatter.java
@@ -602,7 +602,10 @@ public class ExpressionFormatter implements ExpressionVisitor<ExpressionString> 
 	@Override
 	public ExpressionString visitSubtypeCast(SubtypeCastExpression expression) {
 
-		return expression.value.accept(this);
+		StringBuilder result = new StringBuilder(expression.value.accept(this).value);
+		result.append(" as ");
+		result.append(typeFormatter.format(expression.type));
+		return new ExpressionString(result.toString(), ZenScriptOperator.CAST);
 	}
 
 	@Override

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/HighLevelDefinition.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/HighLevelDefinition.java
@@ -57,9 +57,12 @@ public abstract class HighLevelDefinition extends Taggable {
 	}
 
 	public boolean isSubclassOf(HighLevelDefinition other) {
+		if(superType == null){
+			return false;
+		}
 		if (superType.isDefinition(other))
 			return true;
-		if (superType == null || !(superType instanceof DefinitionTypeID))
+		if (!(superType instanceof DefinitionTypeID))
 			return false;
 
 		DefinitionTypeID superDefinition = (DefinitionTypeID) superType;

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/expression/ExpressionVisitor.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/expression/ExpressionVisitor.java
@@ -133,6 +133,8 @@ public interface ExpressionVisitor<T> {
 
 	T visitSupertypeCast(SupertypeCastExpression expression);
 
+	T visitSubtypeCast(SubtypeCastExpression expression);
+
 	T visitThis(ThisExpression expression);
 
 	T visitThrow(ThrowExpression expression);

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/expression/ExpressionVisitorWithContext.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/expression/ExpressionVisitorWithContext.java
@@ -129,6 +129,8 @@ public interface ExpressionVisitorWithContext<C, R> {
 
 	R visitSupertypeCast(C context, SupertypeCastExpression expression);
 
+	R visitSubtypeCast(C context, SubtypeCastExpression expression);
+
 	R visitThis(C context, ThisExpression expression);
 
 	R visitThrow(C context, ThrowExpression expression);

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/expression/SubtypeCastExpression.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/expression/SubtypeCastExpression.java
@@ -1,0 +1,39 @@
+package org.openzen.zenscript.codemodel.expression;
+
+import org.openzen.zencode.shared.CodePosition;
+import org.openzen.zenscript.codemodel.scope.TypeScope;
+import org.openzen.zenscript.codemodel.type.TypeID;
+
+/**
+ * Using to cast a base type to a class type.
+ */
+public class SubtypeCastExpression extends Expression {
+	public final Expression value;
+
+	public SubtypeCastExpression(CodePosition position, Expression value, TypeID type) {
+		super(position, type, value.thrownType);
+
+		this.value = value;
+	}
+
+	@Override
+	public <T> T accept(ExpressionVisitor<T> visitor) {
+		return visitor.visitSubtypeCast(this);
+	}
+
+	@Override
+	public <C, R> R accept(C context, ExpressionVisitorWithContext<C, R> visitor) {
+		return visitor.visitSubtypeCast(context, this);
+	}
+
+	@Override
+	public Expression transform(ExpressionTransformer transformer) {
+		Expression tValue = value.transform(transformer);
+		return tValue == value ? this : new SubtypeCastExpression(position, tValue, type);
+	}
+
+	@Override
+	public Expression normalize(TypeScope scope) {
+		return new SubtypeCastExpression(position, value.normalize(scope), type.getNormalized());
+	}
+}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
@@ -1,5 +1,6 @@
 package org.openzen.zenscript.codemodel.type;
 
+import org.openzen.zencode.shared.CodePosition;
 import org.openzen.zenscript.codemodel.GenericMapper;
 import org.openzen.zenscript.codemodel.GenericName;
 import org.openzen.zenscript.codemodel.HighLevelDefinition;
@@ -7,6 +8,10 @@ import org.openzen.zenscript.codemodel.definition.AliasDefinition;
 import org.openzen.zenscript.codemodel.definition.EnumDefinition;
 import org.openzen.zenscript.codemodel.definition.StructDefinition;
 import org.openzen.zenscript.codemodel.definition.VariantDefinition;
+import org.openzen.zenscript.codemodel.expression.CastExpression;
+import org.openzen.zenscript.codemodel.expression.Expression;
+import org.openzen.zenscript.codemodel.expression.SubtypeCastExpression;
+import org.openzen.zenscript.codemodel.expression.SupertypeCastExpression;
 import org.openzen.zenscript.codemodel.generic.TypeParameter;
 
 import java.util.*;
@@ -239,4 +244,18 @@ public class DefinitionTypeID implements TypeID {
 		HighLevelDefinition type = definition.getInnerType(name.name);
 		return registry.getForDefinition(type, name.arguments, this);
 	}
+
+	@Override
+	public boolean canCastImplicitFrom(TypeID other) {
+		if (!(other instanceof DefinitionTypeID)) {
+			return false;
+		}
+		return this.definition.isSubclassOf(((DefinitionTypeID) other).definition);
+	}
+
+	@Override
+	public Expression castImplicitFrom(CodePosition position, Expression value) {
+		return new SubtypeCastExpression(position, value, this);
+	}
+
 }

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
@@ -8,16 +8,14 @@ import org.openzen.zenscript.codemodel.definition.AliasDefinition;
 import org.openzen.zenscript.codemodel.definition.EnumDefinition;
 import org.openzen.zenscript.codemodel.definition.StructDefinition;
 import org.openzen.zenscript.codemodel.definition.VariantDefinition;
-import org.openzen.zenscript.codemodel.expression.CastExpression;
 import org.openzen.zenscript.codemodel.expression.Expression;
 import org.openzen.zenscript.codemodel.expression.SubtypeCastExpression;
-import org.openzen.zenscript.codemodel.expression.SupertypeCastExpression;
 import org.openzen.zenscript.codemodel.generic.TypeParameter;
 import org.openzen.zenscript.codemodel.member.IDefinitionMember;
 import org.openzen.zenscript.codemodel.member.ImplementationMember;
 
 import java.util.*;
-import java.util.stream.Stream;
+import java.util.function.Predicate;
 
 public class DefinitionTypeID implements TypeID {
 	public final HighLevelDefinition definition;
@@ -258,34 +256,37 @@ public class DefinitionTypeID implements TypeID {
 			return true;
 		}
 
-		HashSet<DefinitionTypeID> superTypes = new HashSet<>();
-		collectSuperTypes(superTypes, this);
-
-		Set<ImplementationMember> members = new HashSet<>();
-		Stream.concat(superTypes.stream()
-				.flatMap(type -> type.definition.members.stream()), this.definition.members.stream())
-				.forEach(member -> collectImplementationMembers(members, member));
-
-		return members.stream().anyMatch(member -> member.type == other);
+		Predicate<IDefinitionMember> search = member -> member instanceof ImplementationMember && ((ImplementationMember) member).type == other;
+		return searchSuperTypes(this, search) || searchImplementationMembers(this, search);
 	}
 
-	private void collectSuperTypes(Set<DefinitionTypeID> superTypes, DefinitionTypeID type){
+	private boolean searchSuperTypes(DefinitionTypeID type, Predicate<IDefinitionMember> predicate) {
 		TypeID superType = type.definition.getSuperType();
-		if(superType instanceof DefinitionTypeID) {
+		if (superType instanceof DefinitionTypeID) {
 			DefinitionTypeID definitionSuperType = (DefinitionTypeID) superType;
-			superTypes.add(definitionSuperType);
-			collectSuperTypes(superTypes, definitionSuperType);
+			boolean found = definitionSuperType.definition.members.stream().anyMatch(predicate);
+
+			return found || searchSuperTypes(definitionSuperType, predicate);
 		}
+		return false;
 	}
 
-	private void collectImplementationMembers(Set<ImplementationMember> members, IDefinitionMember member) {
-		if (member instanceof ImplementationMember) {
-			ImplementationMember implMember = (ImplementationMember) member;
-			members.add(implMember);
-			if(implMember.type instanceof DefinitionTypeID){
-				((DefinitionTypeID) implMember.type).definition.members.forEach(innerMember -> collectImplementationMembers(members,innerMember));
+	private boolean searchImplementationMembers(DefinitionTypeID type, Predicate<IDefinitionMember> predicate) {
+		for (IDefinitionMember member : type.definition.members) {
+			if (member instanceof ImplementationMember) {
+				ImplementationMember implMember = (ImplementationMember) member;
+				if (predicate.test(implMember)) {
+					return true;
+				}
+				if (implMember.type instanceof DefinitionTypeID) {
+					if (searchImplementationMembers((DefinitionTypeID) implMember.type, predicate)) {
+						return true;
+					}
+				}
 			}
 		}
+
+		return false;
 	}
 
 	@Override

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
@@ -161,6 +161,12 @@ public class DefinitionTypeID implements TypeID {
 	}
 
 	@Override
+	public boolean isDefinition(HighLevelDefinition definition) {
+
+		return this.definition.equals(definition);
+	}
+
+	@Override
 	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
 		if (hasTypeParameters()) {
 			for (TypeID typeArgument : typeArguments)

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/member/TypeMembers.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/member/TypeMembers.java
@@ -574,8 +574,6 @@ public final class TypeMembers {
 			return castImplicit(position, value, toType, false);
 		if (type.canCastExplicitTo(toType))
 			return type.castExplicitTo(position, value, toType);
-		if (toType.canCastExplicitFrom(type))
-			return toType.castImplicitFrom(position, value);
 
 		final TypeMembers typeMembers = cache.get(type);
 		if (this.type != typeMembers.type && typeMembers.canCast(toType)) {
@@ -585,6 +583,13 @@ public final class TypeMembers {
 		for (TypeMember<CasterMemberRef> caster : casters)
 			if (caster.member.toType == toType)
 				return caster.member.cast(position, value, false);
+
+
+		if (toType.canCastImplicitFrom(type))
+			return toType.castImplicitFrom(position, value);
+
+
+
 
 		return new InvalidExpression(position, toType, CompileExceptionCode.INVALID_CAST, "Cannot cast " + this + " to " + toType + ", even explicitly");
 	}

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaExpressionVisitor.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaExpressionVisitor.java
@@ -29,6 +29,7 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Collectors;
 
+@SuppressWarnings("ALL")
 public class JavaExpressionVisitor implements ExpressionVisitor<Void>, JavaNativeTranslator<Void> {
 	public static final JavaMethod OBJECT_HASHCODE = JavaMethod.getNativeVirtual(JavaClass.OBJECT, "hashCode", "()I");
 	public static final JavaMethod OBJECT_EQUALS = JavaMethod.getNativeVirtual(JavaClass.OBJECT, "equals", "(Ljava/lang/Object)Z");
@@ -3286,6 +3287,13 @@ public class JavaExpressionVisitor implements ExpressionVisitor<Void>, JavaNativ
 	@Override
 	public Void visitSupertypeCast(SupertypeCastExpression expression) {
 		expression.value.accept(this);
+		return null; // nothing to do
+	}
+
+	@Override
+	public Void visitSubtypeCast(SubtypeCastExpression expression) {
+		expression.value.accept(this);
+		javaWriter.checkCast(context.getType(expression.type));
 		return null; // nothing to do
 	}
 

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaExpressionVisitor.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaExpressionVisitor.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Modifier;
 import java.util.*;
 import java.util.stream.Collectors;
 
-@SuppressWarnings("ALL")
 public class JavaExpressionVisitor implements ExpressionVisitor<Void>, JavaNativeTranslator<Void> {
 	public static final JavaMethod OBJECT_HASHCODE = JavaMethod.getNativeVirtual(JavaClass.OBJECT, "hashCode", "()I");
 	public static final JavaMethod OBJECT_EQUALS = JavaMethod.getNativeVirtual(JavaClass.OBJECT, "equals", "(Ljava/lang/Object)Z");

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaModificationExpressionVisitor.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaModificationExpressionVisitor.java
@@ -383,6 +383,11 @@ public class JavaModificationExpressionVisitor implements ExpressionVisitor<Void
 	}
 
 	@Override
+	public Void visitSubtypeCast(SubtypeCastExpression expression) {
+		throw new UnsupportedOperationException("Invalid lvalue: cast");
+	}
+
+	@Override
 	public Void visitThis(ThisExpression expression) {
 		throw new UnsupportedOperationException("Invalid lvalue: this");
 	}

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaNonPushingExpressionVisitor.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaNonPushingExpressionVisitor.java
@@ -593,6 +593,11 @@ public class JavaNonPushingExpressionVisitor implements ExpressionVisitor<Void> 
 	}
 
 	@Override
+	public Void visitSubtypeCast(SubtypeCastExpression expression) {
+		return expression.value.accept(this);
+	}
+
+	@Override
 	public Void visitThis(ThisExpression expression) {
 		return null;
 	}

--- a/Validator/src/main/java/org/openzen/zenscript/validator/visitors/ExpressionValidator.java
+++ b/Validator/src/main/java/org/openzen/zenscript/validator/visitors/ExpressionValidator.java
@@ -667,6 +667,12 @@ public class ExpressionValidator implements ExpressionVisitor<Void> {
 	}
 
 	@Override
+	public Void visitSubtypeCast(SubtypeCastExpression expression) {
+		expression.value.accept(this);
+		return null;
+	}
+
+	@Override
 	public Void visitThis(ThisExpression expression) {
 		if (!scope.hasThis()) {
 			validator.logError(ValidationLogEntry.Code.THIS_IN_STATIC_SCOPE, expression.position, "Cannot use this in a static scope");


### PR DESCRIPTION
With the following code:
```java
public class Parent {

    @ZenCodeType.Method
    public String name(){
        return "Parent";
    }

}

public class Child extends Parent {

    @ZenCodeType.Method
    public void test(){
        System.out.println("test");
    }

    @Override
    public String name() {

        return "child";
    }
}

@Global
    public static Parent getParent() {
        return new Parent();
    }

    @Global
    public static Parent getChild() {
        return new Child();
    }

```

and the following script:
```zenscript
var parent = getChild();
if parent is Child {
    println(parent.name());
    parent.test();
}
```

Things work as they should, even though `getParent` return type is `Parent`, the object is still a child so `Child` methods work on it.

Also doing 
```zenscript
parent as Child;
```
works, even though it isn't required.