### PR TITLE
fix array inheritance

### DIFF
--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/member/TypeMembers.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/member/TypeMembers.java
@@ -73,6 +73,12 @@ public final class TypeMembers {
 				break checkBoundaries;
 			}
 			return true;
+		} else if (this.type instanceof ArrayTypeID && other instanceof ArrayTypeID) {
+			TypeID thisElementType = ((ArrayTypeID) this.type).elementType;
+			TypeID otherElementType = ((ArrayTypeID) other).elementType;
+			if (cache.get(thisElementType).extendsOrImplements(otherElementType)) {
+				return true;
+			}
 		}
 
 


### PR DESCRIPTION
Basically if array's type extends or implements another array's type, they should be able to cast to each other.