### PR TITLE
Use compile instead of compileKey when filling out array contents

### DIFF
--- a/Parser/src/main/java/org/openzen/zenscript/parser/expression/ParsedExpressionArray.java
+++ b/Parser/src/main/java/org/openzen/zenscript/parser/expression/ParsedExpressionArray.java
@@ -66,7 +66,7 @@ public class ParsedExpressionArray extends ParsedExpression {
 			ExpressionScope contentScope = scope.withoutHints();
 			TypeID resultType = null;
 			for (int i = 0; i < contents.size(); i++) {
-				cContents[i] = contents.get(i).compileKey(contentScope).eval();
+				cContents[i] = contents.get(i).compile(contentScope).eval();
 				TypeID joinedType = resultType == null ? cContents[i].type : scope.getTypeMembers(resultType).union(cContents[i].type);
 				if (joinedType == null)
 					throw new CompileException(position, CompileExceptionCode.TYPE_CANNOT_UNITE, "Could not combine " + resultType + " with " + cContents[i].type);


### PR DESCRIPTION
```zenscript
function t(theThing as string) as void {

	doThing([theThing]);
}

t("test");
```
would compile as:
```java
    static void t(String var0) {
        Globals.doThing(new String[]{"theThing"});
    }
```

Which is not ideal...