### PR TITLE
Fix circular inference blocking type

### DIFF
--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/FunctionHeader.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/FunctionHeader.java
@@ -5,10 +5,7 @@ import org.openzen.zenscript.codemodel.expression.CallArguments;
 import org.openzen.zenscript.codemodel.expression.Expression;
 import org.openzen.zenscript.codemodel.generic.TypeParameter;
 import org.openzen.zenscript.codemodel.scope.TypeScope;
-import org.openzen.zenscript.codemodel.type.ArrayTypeID;
-import org.openzen.zenscript.codemodel.type.BasicTypeID;
-import org.openzen.zenscript.codemodel.type.GlobalTypeRegistry;
-import org.openzen.zenscript.codemodel.type.TypeID;
+import org.openzen.zenscript.codemodel.type.*;
 
 import java.util.Arrays;
 import java.util.Map;
@@ -304,8 +301,9 @@ public class FunctionHeader {
 	}
 
 	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
+		InferenceBlockingTypeParameterVisitor inferenceBlockingVisitor = new InferenceBlockingTypeParameterVisitor(parameters);
 		for (int i = 0; i < this.parameters.length; i++)
-			if (this.parameters[i].type.hasInferenceBlockingTypeParameters(parameters))
+			if (this.parameters[i].type.accept(inferenceBlockingVisitor))
 				return true;
 
 		return false;

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/ArrayTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/ArrayTypeID.java
@@ -64,11 +64,6 @@ public class ArrayTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return elementType.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return false;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/AssocTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/AssocTypeID.java
@@ -53,11 +53,6 @@ public class AssocTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return keyType.hasInferenceBlockingTypeParameters(parameters) || valueType.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return true;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/BasicTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/BasicTypeID.java
@@ -74,11 +74,6 @@ public enum BasicTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return false;
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return true;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/DefinitionTypeID.java
@@ -173,18 +173,6 @@ public class DefinitionTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		if (hasTypeParameters()) {
-			for (TypeID typeArgument : typeArguments)
-				if (typeArgument.hasInferenceBlockingTypeParameters(parameters))
-					return true;
-		}
-
-		TypeID superType = definition.getSuperType();
-		return superType != null && superType.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public int hashCode() {
 		int hash = 7;
 		hash = 97 * hash + definition.hashCode();

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/FunctionTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/FunctionTypeID.java
@@ -50,11 +50,6 @@ public class FunctionTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return header.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return false;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/GenericMapTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/GenericMapTypeID.java
@@ -49,11 +49,6 @@ public class GenericMapTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return value.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return true;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/GenericTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/GenericTypeID.java
@@ -53,15 +53,6 @@ public class GenericTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		for (TypeParameter parameter : parameters)
-			if (parameter == this.parameter)
-				return true;
-
-		return false;
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return false;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/InferenceBlockingTypeParameterVisitor.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/InferenceBlockingTypeParameterVisitor.java
@@ -1,0 +1,268 @@
+package org.openzen.zenscript.codemodel.type;
+
+import org.openzen.zenscript.codemodel.generic.TypeParameter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Visitor to determine if a type has inference blocking type parameters.
+ * <p>
+ * This works by adding the known types to a map, and quering the map to see if
+ * a type has been seen before.
+ * <p>
+ * Types are first added to the map with a value of false, to indicate that it is
+ * currently being visited.
+ * <p>
+ * This is done to resolve circular types (see MyEnum extends Enum<MyEnum>).
+ * <p>
+ * After extra processing is done (such as {@link ArrayTypeID} checking its element's type to determine if it blocks),
+ * the actual result of if the type blocks is inserted into the map.
+ */
+public class InferenceBlockingTypeParameterVisitor implements TypeVisitor<Boolean> {
+
+	private final TypeParameter[] parameters;
+	private final Map<TypeID, Boolean> visitedTypes;
+
+	public InferenceBlockingTypeParameterVisitor(TypeParameter[] parameters) {
+		this.parameters = parameters;
+		this.visitedTypes = new HashMap<>();
+	}
+
+	@Override
+	public Boolean visitBasic(BasicTypeID basic) {
+		Optional<Boolean> knownResult = getKnownResult(basic);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(basic, false);
+		return false;
+	}
+
+	@Override
+	public Boolean visitArray(ArrayTypeID array) {
+		Optional<Boolean> knownResult = getKnownResult(array);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+
+		visitedTypes.put(array, false);
+
+		TypeID elementType = array.elementType;
+		Optional<Boolean> knownElementType = getKnownResult(elementType);
+		if (knownElementType.isPresent()) {
+			visitedTypes.put(array, knownElementType.get());
+			return knownElementType.get();
+		}
+		visitedTypes.putIfAbsent(elementType, false);
+		Boolean blocking = elementType.accept(this);
+		visitedTypes.put(elementType, blocking);
+		visitedTypes.put(array, blocking);
+		return blocking;
+	}
+
+	@Override
+	public Boolean visitAssoc(AssocTypeID assoc) {
+		Optional<Boolean> knownResult = getKnownResult(assoc);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(assoc, false);
+		TypeID keyType = assoc.keyType;
+		Optional<Boolean> knownKeyType = getKnownResult(keyType);
+		if (knownKeyType.isPresent()) {
+			visitedTypes.put(assoc, knownKeyType.get());
+			return knownKeyType.get();
+		}
+		visitedTypes.putIfAbsent(keyType, false);
+		Boolean keyBlocking = keyType.accept(this);
+		visitedTypes.put(keyType, keyBlocking);
+		visitedTypes.put(assoc, keyBlocking);
+		if (keyBlocking) {
+			return true;
+		}
+		TypeID valueType = assoc.valueType;
+		Optional<Boolean> knownValueType = getKnownResult(valueType);
+		if (knownValueType.isPresent()) {
+			visitedTypes.put(assoc, knownValueType.get());
+			return knownValueType.get();
+		}
+		visitedTypes.putIfAbsent(valueType, false);
+		Boolean valueBlocking = valueType.accept(this);
+		visitedTypes.put(valueType, valueBlocking);
+		visitedTypes.put(assoc, valueBlocking);
+		return valueBlocking;
+	}
+
+	@Override
+	public Boolean visitGenericMap(GenericMapTypeID map) {
+		Optional<Boolean> knownResult = getKnownResult(map);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(map, false);
+		TypeID value = map.value;
+		Optional<Boolean> knownValue = getKnownResult(value);
+		if (knownValue.isPresent()) {
+			visitedTypes.put(map, knownValue.get());
+			return knownValue.get();
+		}
+		visitedTypes.putIfAbsent(value, false);
+		Boolean blocking = value.accept(this);
+		visitedTypes.put(value, blocking);
+		visitedTypes.put(map, blocking);
+		return blocking;
+	}
+
+	@Override
+	public Boolean visitIterator(IteratorTypeID iterator) {
+		Optional<Boolean> knownResult = getKnownResult(iterator);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(iterator, false);
+		for (TypeID type : iterator.iteratorTypes) {
+			Optional<Boolean> knownType = getKnownResult(type);
+			if (knownType.isPresent() && knownType.get()) {
+				visitedTypes.put(iterator, true);
+				return true;
+			}
+			visitedTypes.put(type, false);
+			Boolean blocking = type.accept(this);
+			visitedTypes.put(type, blocking);
+			if (blocking) {
+				visitedTypes.put(iterator, true);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Boolean visitFunction(FunctionTypeID function) {
+		Optional<Boolean> knownResult = getKnownResult(function);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(function, false);
+		boolean blocking = function.header.hasInferenceBlockingTypeParameters(parameters);
+		visitedTypes.put(function, blocking);
+		return blocking;
+	}
+
+	@Override
+	public Boolean visitDefinition(DefinitionTypeID definition) {
+		Optional<Boolean> knownResult = getKnownResult(definition);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(definition, false);
+		if (definition.hasTypeParameters()) {
+			for (TypeID typeArgument : definition.typeArguments) {
+				Optional<Boolean> knownType = getKnownResult(typeArgument);
+				if (knownType.isPresent() && knownType.get()) {
+					visitedTypes.put(definition, true);
+					return true;
+				}
+				visitedTypes.put(typeArgument, false);
+				boolean blocking = typeArgument.accept(this);
+				visitedTypes.put(typeArgument, blocking);
+				if (blocking) {
+					visitedTypes.put(definition, true);
+					return true;
+				}
+			}
+		}
+
+		TypeID superType = definition.definition.getSuperType();
+		if (superType != null) {
+			Optional<Boolean> knownSuperType = getKnownResult(superType);
+			if (knownSuperType.isPresent() && knownSuperType.get()) {
+				visitedTypes.put(definition, true);
+				return true;
+			}
+			visitedTypes.put(superType, false);
+			Boolean blocking = superType.accept(this);
+			visitedTypes.put(superType, blocking);
+			if (blocking) {
+				visitedTypes.put(definition, true);
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Override
+	public Boolean visitGeneric(GenericTypeID generic) {
+		Optional<Boolean> knownResult = getKnownResult(generic);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		for (TypeParameter parameter : parameters) {
+			if (parameter == generic.parameter) {
+				visitedTypes.put(generic, true);
+				return true;
+			}
+		}
+		visitedTypes.put(generic, false);
+		return false;
+	}
+
+	@Override
+	public Boolean visitRange(RangeTypeID range) {
+		Optional<Boolean> knownResult = getKnownResult(range);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(range, false);
+		TypeID baseType = range.baseType;
+		Optional<Boolean> knownElementType = getKnownResult(baseType);
+		if (knownElementType.isPresent()) {
+			visitedTypes.put(range, knownElementType.get());
+			return knownElementType.get();
+		}
+		visitedTypes.putIfAbsent(baseType, false);
+		Boolean blocking = baseType.accept(this);
+		visitedTypes.put(baseType, blocking);
+		visitedTypes.put(range, blocking);
+		return blocking;
+	}
+
+	@Override
+	public Boolean visitOptional(OptionalTypeID type) {
+		Optional<Boolean> knownResult = getKnownResult(type);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(type, false);
+		TypeID baseType = type.baseType;
+		Optional<Boolean> knownElementType = getKnownResult(baseType);
+		if (knownElementType.isPresent()) {
+			visitedTypes.put(type, knownElementType.get());
+			return knownElementType.get();
+		}
+		visitedTypes.putIfAbsent(baseType, false);
+		Boolean blocking = baseType.accept(this);
+		visitedTypes.put(baseType, blocking);
+		visitedTypes.put(type, blocking);
+		return blocking;
+	}
+
+	@Override
+	public Boolean visitInvalid(InvalidTypeID type) {
+		Optional<Boolean> knownResult = getKnownResult(type);
+		if (knownResult.isPresent()) {
+			return knownResult.get();
+		}
+		visitedTypes.put(type, false);
+		return false;
+	}
+
+	private Optional<Boolean> getKnownResult(TypeID type) {
+		if (visitedTypes.containsKey(type)) {
+			return Optional.of(visitedTypes.get(type));
+		}
+		return Optional.empty();
+	}
+}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/InvalidTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/InvalidTypeID.java
@@ -29,11 +29,6 @@ public class InvalidTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return false;
-	}
-
-	@Override
 	public void extractTypeParameters(List<TypeParameter> typeParameters) {
 
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/IteratorTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/IteratorTypeID.java
@@ -63,15 +63,6 @@ public class IteratorTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		for (TypeID type : iteratorTypes)
-			if (type.hasInferenceBlockingTypeParameters(parameters))
-				return true;
-
-		return false;
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return false;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/OptionalTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/OptionalTypeID.java
@@ -61,11 +61,6 @@ public class OptionalTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return baseType.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return isOptional() || baseType.hasDefaultValue();
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/RangeTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/RangeTypeID.java
@@ -53,11 +53,6 @@ public class RangeTypeID implements TypeID {
 	}
 
 	@Override
-	public boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters) {
-		return baseType.hasInferenceBlockingTypeParameters(parameters);
-	}
-
-	@Override
 	public boolean hasDefaultValue() {
 		return false;
 	}

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/TypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/TypeID.java
@@ -38,8 +38,6 @@ public interface TypeID {
 
 	boolean hasDefaultValue();
 
-	boolean hasInferenceBlockingTypeParameters(TypeParameter[] parameters);
-
 	default Expression getDefaultValue() {
 		return null;
 	}

--- a/Parser/src/main/java/org/openzen/zenscript/parser/expression/ParsedCallArguments.java
+++ b/Parser/src/main/java/org/openzen/zenscript/parser/expression/ParsedCallArguments.java
@@ -12,6 +12,7 @@ import org.openzen.zenscript.codemodel.generic.TypeParameter;
 import org.openzen.zenscript.codemodel.partial.IPartialExpression;
 import org.openzen.zenscript.codemodel.scope.BaseScope;
 import org.openzen.zenscript.codemodel.scope.ExpressionScope;
+import org.openzen.zenscript.codemodel.type.InferenceBlockingTypeParameterVisitor;
 import org.openzen.zenscript.codemodel.type.InvalidTypeID;
 import org.openzen.zenscript.codemodel.type.TypeID;
 import org.openzen.zenscript.codemodel.type.member.TypeMemberGroup;
@@ -243,9 +244,10 @@ public class ParsedCallArguments {
 
 		//TODO: This is wrong
 		boolean variadic = header.isVariadic();
+		InferenceBlockingTypeParameterVisitor inferenceBlockingVisitor = new InferenceBlockingTypeParameterVisitor(header.typeParameters);
 		for (int i = 0; i < arguments.size(); i++) {
 			FunctionParameter parameter = header.getParameter(variadic, i);
-			if (typeArguments == null && parameter.type.hasInferenceBlockingTypeParameters(header.typeParameters))
+			if (typeArguments == null && parameter.type.accept(inferenceBlockingVisitor))
 				return false;
 
 			if (!arguments.get(i).isCompatibleWith(scope, header.getParameterType(variadic, i).getNormalized()))

--- a/ScriptingExample/src/test/java/org/openzen/zenscript/scriptingexample/tests/actual_test/joined_tests/TypeInferenceBlockingTest.java
+++ b/ScriptingExample/src/test/java/org/openzen/zenscript/scriptingexample/tests/actual_test/joined_tests/TypeInferenceBlockingTest.java
@@ -1,0 +1,39 @@
+package org.openzen.zenscript.scriptingexample.tests.actual_test.joined_tests;
+
+import org.junit.jupiter.api.Test;
+import org.openzen.zencode.java.ZenCodeType;
+import org.openzen.zenscript.scriptingexample.tests.helpers.ScriptBuilder;
+import org.openzen.zenscript.scriptingexample.tests.helpers.ZenCodeTest;
+
+import java.util.List;
+
+public class TypeInferenceBlockingTest extends ZenCodeTest {
+
+	@Test
+	public void doTheTest() {
+		ScriptBuilder.create()
+				.add("public class MyClass {")
+				.add("		public this(thing as test_module.MyEnum) {")
+				.add("		println(thing.name);")
+				.add("	}")
+				.add("}")
+				.add("new MyClass(test_module.MyEnum.A);")
+				.execute(this);
+
+		logger.assertPrintOutputSize(1);
+		logger.assertPrintOutput(0, "A");
+	}
+
+
+	@Override
+	public List<Class<?>> getRequiredClasses() {
+		final List<Class<?>> requiredClasses = super.getRequiredClasses();
+		requiredClasses.add(MyEnum.class);
+		return requiredClasses;
+	}
+
+	@ZenCodeType.Name("test_module.MyEnum")
+	public enum MyEnum {
+		A, B, C
+	}
+}


### PR DESCRIPTION
Fixes using enums in constructors (would get stuck on `MyEnum extends Enum<MyEnum>`)