### PR TITLE
Fixed JavaFunctionalInterfaceTypeID losing it's meaning when normalized or instanced.

### DIFF
--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/FunctionTypeID.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/FunctionTypeID.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class FunctionTypeID implements TypeID {
 	public final FunctionHeader header;
-	private final FunctionTypeID normalized;
+	protected final FunctionTypeID normalized;
 
 	public FunctionTypeID(GlobalTypeRegistry registry, FunctionHeader header) {
 		this.header = header;

--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/GlobalTypeRegistry.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/type/GlobalTypeRegistry.java
@@ -11,6 +11,9 @@ import java.util.Map;
 
 public class GlobalTypeRegistry {
 	public final ZSPackage stdlib;
+	// Allows for internalizing any TypeID not defined here.
+	private final Map<Class<? extends TypeID>, Map<? extends TypeID, ? extends TypeID>> identityMaps = new HashMap<>();
+
 	private final Map<ArrayTypeID, ArrayTypeID> arrayTypes = new HashMap<>();
 	private final Map<AssocTypeID, AssocTypeID> assocTypes = new HashMap<>();
 	private final Map<GenericMapTypeID, GenericMapTypeID> genericMapTypes = new HashMap<>();
@@ -29,6 +32,15 @@ public class GlobalTypeRegistry {
 
 		rangeTypes.put(RangeTypeID.INT, RangeTypeID.INT);
 		rangeTypes.put(RangeTypeID.USIZE, RangeTypeID.USIZE);
+		identityMaps.put(ArrayTypeID.class, arrayTypes);
+		identityMaps.put(AssocTypeID.class, assocTypes);
+		identityMaps.put(GenericMapTypeID.class, genericMapTypes);
+		identityMaps.put(IteratorTypeID.class, iteratorTypes);
+		identityMaps.put(FunctionTypeID.class, functionTypes);
+		identityMaps.put(RangeTypeID.class, rangeTypes);
+		identityMaps.put(DefinitionTypeID.class, definitionTypes);
+		identityMaps.put(GenericTypeID.class, genericTypes);
+		identityMaps.put(OptionalTypeID.class, optionalTypes);
 	}
 
 	public ArrayTypeID getArray(TypeID baseType, int dimension) {
@@ -94,6 +106,16 @@ public class GlobalTypeRegistry {
 	}
 
 	private <T> T internalize(Map<T, T> identityMap, T id) {
+		if (identityMap.containsKey(id)) {
+			return identityMap.get(id);
+		} else {
+			identityMap.put(id, id);
+			return id;
+		}
+	}
+
+	public <T extends TypeID> T internalize(Class<T> clazz, T id) {
+		Map<T, T> identityMap = (Map<T, T>) identityMaps.computeIfAbsent(clazz, aClass -> new HashMap<>());
 		if (identityMap.containsKey(id)) {
 			return identityMap.get(id);
 		} else {

--- a/JavaShared/src/main/java/org/openzen/zenscript/javashared/types/JavaFunctionalInterfaceTypeID.java
+++ b/JavaShared/src/main/java/org/openzen/zenscript/javashared/types/JavaFunctionalInterfaceTypeID.java
@@ -2,6 +2,7 @@ package org.openzen.zenscript.javashared.types;
 
 import org.openzen.zencode.shared.CodePosition;
 import org.openzen.zenscript.codemodel.FunctionHeader;
+import org.openzen.zenscript.codemodel.GenericMapper;
 import org.openzen.zenscript.codemodel.expression.Expression;
 import org.openzen.zenscript.codemodel.type.FunctionTypeID;
 import org.openzen.zenscript.codemodel.type.GlobalTypeRegistry;
@@ -14,12 +15,21 @@ import java.lang.reflect.Method;
 public class JavaFunctionalInterfaceTypeID extends FunctionTypeID {
 	public final Method functionalInterfaceMethod;
 	public final JavaMethod method;
+	private final FunctionTypeID normalized;
 
 	public JavaFunctionalInterfaceTypeID(GlobalTypeRegistry registry, FunctionHeader header, Method functionalInterfaceMethod, JavaMethod method) {
 		super(registry, header);
 
 		this.functionalInterfaceMethod = functionalInterfaceMethod;
 		this.method = method;
+
+		FunctionHeader normalizedHeader = header.normalize(registry);
+		normalized = header == normalizedHeader ? this : internalizeHeaderChange(registry,normalizedHeader);
+	}
+
+	@Override
+	public TypeID instance(GenericMapper mapper) {
+		return internalizeHeaderChange(mapper.registry,mapper.map(header));
 	}
 
 	@Override
@@ -50,5 +60,10 @@ public class JavaFunctionalInterfaceTypeID extends FunctionTypeID {
 				return new JavaFunctionInterfaceCastExpression(position, this, value);
 		}
 		return null;
+	}
+
+	private JavaFunctionalInterfaceTypeID internalizeHeaderChange(GlobalTypeRegistry registry, FunctionHeader header) {
+		JavaFunctionalInterfaceTypeID normalizedTypeId = new JavaFunctionalInterfaceTypeID(registry, header, functionalInterfaceMethod, method);
+		return registry.internalize(JavaFunctionalInterfaceTypeID.class, normalizedTypeId);
 	}
 }

--- a/JavaShared/src/main/java/org/openzen/zenscript/javashared/types/JavaFunctionalInterfaceTypeID.java
+++ b/JavaShared/src/main/java/org/openzen/zenscript/javashared/types/JavaFunctionalInterfaceTypeID.java
@@ -28,6 +28,11 @@ public class JavaFunctionalInterfaceTypeID extends FunctionTypeID {
 	}
 
 	@Override
+	public FunctionTypeID getNormalized() {
+		return normalized;
+	}
+
+	@Override
 	public TypeID instance(GenericMapper mapper) {
 		return internalizeHeaderChange(mapper.registry,mapper.map(header));
 	}

--- a/ScriptingExample/src/test/java/org/openzen/zenscript/scriptingexample/tests/actual_test/java_native/FunctionalInterfaceTests.java
+++ b/ScriptingExample/src/test/java/org/openzen/zenscript/scriptingexample/tests/actual_test/java_native/FunctionalInterfaceTests.java
@@ -1,0 +1,73 @@
+package org.openzen.zenscript.scriptingexample.tests.actual_test.java_native;
+
+import org.junit.jupiter.api.Test;
+import org.openzen.zencode.java.ZenCodeGlobals;
+import org.openzen.zencode.java.ZenCodeType;
+import org.openzen.zenscript.scriptingexample.tests.SharedGlobals;
+import org.openzen.zenscript.scriptingexample.tests.helpers.ZenCodeTest;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+
+public class FunctionalInterfaceTests extends ZenCodeTest {
+
+	@Override
+	public List<Class<?>> getRequiredClasses() {
+		final List<Class<?>> requiredClasses = super.getRequiredClasses();
+		requiredClasses.add(FunctionalInterfaceTests.TestClass.class);
+		requiredClasses.add(FunctionalInterfaceTests.StringModifier.class);
+		requiredClasses.add(SharedGlobals.class);
+		return requiredClasses;
+	}
+
+	@Test
+	public void testFunctionalInterface() {
+		addScript(
+				"var modified = modifyString('test', (strings, context) => { return strings; });\n" +
+						"for str in modified { println(str); }",
+				"FunctionalInterfaceTests_testFunctionalInterface.zs");
+
+		executeEngine();
+
+		logger.assertNoErrors();
+		logger.assertNoWarnings();
+		logger.assertPrintOutputSize(1);
+		logger.assertPrintOutput(0, "test");
+	}
+
+	@Test
+	public void testBiFunction() {
+		addScript(
+				"var modified = stringFunction('test', (strings, context) => {return strings;});\n" +
+						"for str in modified { println(str); }",
+				"FunctionalInterfaceTests_testBiFunction.zs");
+
+		executeEngine();
+
+		logger.assertNoErrors();
+		logger.assertNoWarnings();
+		logger.assertPrintOutputSize(1);
+		logger.assertPrintOutput(0, "test");
+	}
+
+	@ZenCodeType.Name("test_module.java_native.TestClass")
+	public static final class TestClass {
+		@ZenCodeGlobals.Global
+		public static List<String> modifyString(String baseString, StringModifier modifier) {
+			return modifier.modify(Collections.singletonList(baseString), false);
+		}
+
+		@ZenCodeGlobals.Global
+		public static List<String> stringFunction(String baseString, BiFunction<List<String>, Boolean, List<String>> function) {
+			return function.apply(Collections.singletonList(baseString), false);
+		}
+	}
+
+	@FunctionalInterface
+	@ZenCodeType.Name("test_module.java_native.StringModifier")
+	public static interface StringModifier {
+
+		List<String> modify(List<String> strings, boolean context);
+	}
+}


### PR DESCRIPTION
Previously there were cases where a method may ask for a FunctionalInterface, but ZC would pass it a BiFunction or some other built in function that fit the header, which would then lead to a crash when it was being used.

This PR also includes the ability to internalize any TypeID that isn't available in the codeModel project, which right now is only the JFITI, but best to future proof it in-case there are ever any more.

I was a bit hesitant to move all the maps into the single map, but if you think that is better I can do it.