### PR TITLE
Added order property to SourceFile

### DIFF
--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/JavaCompiler.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/JavaCompiler.java
@@ -100,7 +100,7 @@ public class JavaCompiler {
 			javaScriptParameters[i] = javaParameter;
 		}
 
-		module.scripts.sort(Comparator.comparingInt(a -> a.file.getOrder()));
+		module.scripts.sort((a, b) -> a.file.getOrder() - b.file.getOrder());
 		for (ScriptBlock script : module.scripts) {
 			final SourceFile sourceFile = script.file;
 			final String className = getClassName(sourceFile == null ? null : sourceFile.getFilename());

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/JavaCompiler.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/JavaCompiler.java
@@ -100,6 +100,7 @@ public class JavaCompiler {
 			javaScriptParameters[i] = javaParameter;
 		}
 
+		module.scripts.sort(Comparator.comparingInt(a -> a.file.getOrder()));
 		for (ScriptBlock script : module.scripts) {
 			final SourceFile sourceFile = script.file;
 			final String className = getClassName(sourceFile == null ? null : sourceFile.getFilename());

--- a/Shared/src/main/java/org/openzen/zencode/shared/SourceFile.java
+++ b/Shared/src/main/java/org/openzen/zencode/shared/SourceFile.java
@@ -9,4 +9,8 @@ public interface SourceFile {
 	Reader open() throws IOException;
 
 	void update(String content) throws IOException;
+
+	default int getOrder() {
+		return 0;
+	}
 }


### PR DESCRIPTION
Exposes a new property, order, so that scripts can have an order set.

Scripts are sorted by ascending order, thus lower numbers go first, higher numbers go later.