### PR TITLE
Fix remapped enum constants not using the constant name

### DIFF
--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/member/EnumConstantMember.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/member/EnumConstantMember.java
@@ -9,15 +9,17 @@ public class EnumConstantMember {
 	public final CodePosition position;
 	public final HighLevelDefinition definition;
 	public final String name;
+	public final String fieldName;
 	public final int ordinal;
 
 	public Expression value = null;
 	public NewExpression constructor = null;
 
-	public EnumConstantMember(CodePosition position, HighLevelDefinition definition, String name, int ordinal) {
+	public EnumConstantMember(CodePosition position, HighLevelDefinition definition, String name, String fieldName, int ordinal) {
 		this.position = position;
 		this.definition = definition;
 		this.name = name;
+		this.fieldName = fieldName;
 		this.ordinal = ordinal;
 	}
 }

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaExpressionVisitor.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/JavaExpressionVisitor.java
@@ -2059,7 +2059,7 @@ public class JavaExpressionVisitor implements ExpressionVisitor<Void>, JavaNativ
 
 	@Override
 	public Void visitEnumConstant(EnumConstantExpression expression) {
-		javaWriter.getStaticField(context.getInternalName(expression.type), expression.value.name, context.getDescriptor(expression.type));
+		javaWriter.getStaticField(context.getInternalName(expression.type), expression.value.fieldName, context.getDescriptor(expression.type));
 		return null;
 	}
 

--- a/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/definitions/JavaMemberVisitor.java
+++ b/JavaBytecodeCompiler/src/main/java/org/openzen/zenscript/javabytecode/compiler/definitions/JavaMemberVisitor.java
@@ -363,7 +363,7 @@ public class JavaMemberVisitor implements MemberVisitor<Void> {
 			JavaClass toClass = context.getJavaClass(enumDefinition);
 
 			for (EnumConstantMember constant : enumDefinition.enumConstants) {
-				writer.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_ENUM, constant.name, "L" + toClass.internalName + ";", null, null).visitEnd();
+				writer.visitField(Opcodes.ACC_STATIC | Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL | Opcodes.ACC_ENUM, constant.fieldName, "L" + toClass.internalName + ";", null, null).visitEnd();
 				final String internalName = context.getInternalName(constant.constructor.type);
 				final JavaWriter clinitWriter = clinitStatementVisitor.getJavaWriter();
 				clinitWriter.newObject(internalName);
@@ -375,7 +375,7 @@ public class JavaMemberVisitor implements MemberVisitor<Void> {
 				}
 
 				clinitWriter.invokeSpecial(internalName, "<init>", context.getEnumConstructorDescriptor(constant.constructor.constructor.getHeader()));
-				clinitWriter.putStaticField(internalName, constant.name, "L" + internalName + ";");
+				clinitWriter.putStaticField(internalName, constant.fieldName, "L" + internalName + ";");
 			}
 
 			final JavaWriter clinitWriter = clinitStatementVisitor.getJavaWriter();
@@ -386,7 +386,7 @@ public class JavaMemberVisitor implements MemberVisitor<Void> {
 			for (EnumConstantMember enumConstant : enumConstants) {
 				clinitWriter.dup();
 				clinitWriter.constant(enumConstant.ordinal);
-				clinitWriter.getStaticField(toClass.internalName, enumConstant.name, "L" + toClass.internalName + ";");
+				clinitWriter.getStaticField(toClass.internalName, enumConstant.fieldName, "L" + toClass.internalName + ";");
 				clinitWriter.arrayStore(Type.getType("L" + toClass.internalName + ";"));
 			}
 			clinitWriter.putStaticField(toClass.internalName, "$VALUES", "[L" + toClass.internalName + ";");

--- a/JavaIntegration/src/main/java/org/openzen/zencode/java/module/converters/JavaNativeClassConverter.java
+++ b/JavaIntegration/src/main/java/org/openzen/zencode/java/module/converters/JavaNativeClassConverter.java
@@ -365,8 +365,10 @@ public class JavaNativeClassConverter {
 		}
 
 		try {
-			final int ordinal = ((Enum<?>) field.get(null)).ordinal();
-			final EnumConstantMember enumConstantMember = new EnumConstantMember(CodePosition.NATIVE, definition, field.getName(), ordinal);
+			final Enum<?> constant = (Enum<?>) field.get(null);
+			final String name = constant.name();
+			final int ordinal = constant.ordinal();
+			final EnumConstantMember enumConstantMember = new EnumConstantMember(CodePosition.NATIVE, definition, name, field.getName(), ordinal);
 			((EnumDefinition) definition).addEnumConstant(enumConstantMember);
 		} catch (IllegalAccessException ex) {
 			throw new IllegalArgumentException("Could not add enum member: " + ex);

--- a/Parser/src/main/java/org/openzen/zenscript/parser/definitions/ParsedEnumConstant.java
+++ b/Parser/src/main/java/org/openzen/zenscript/parser/definitions/ParsedEnumConstant.java
@@ -32,7 +32,7 @@ public class ParsedEnumConstant {
 		this.arguments = arguments;
 		this.value = expressionValue;
 
-		compiled = new EnumConstantMember(position, definition, name, value);
+		compiled = new EnumConstantMember(position, definition, name, name, value);
 	}
 
 	public static ParsedEnumConstant parse(ZSTokenParser tokens, EnumDefinition definition, int value) throws ParseException {

--- a/Validator/src/main/java/org/openzen/zenscript/validator/visitors/DefinitionMemberValidator.java
+++ b/Validator/src/main/java/org/openzen/zenscript/validator/visitors/DefinitionMemberValidator.java
@@ -187,6 +187,7 @@ public class DefinitionMemberValidator implements MemberVisitor<Void> {
 
 	public void visitEnumConstant(EnumConstantMember member) {
 		ValidationUtils.validateIdentifier(validator, member.position, member.name);
+		ValidationUtils.validateIdentifier(validator, member.position, member.fieldName);
 		if (member.constructor != null) {
 			member.constructor.accept(new ExpressionValidator(validator, new EnumConstantInitializerScope()));
 		}


### PR DESCRIPTION
Currently because Minecraft is remapped, the fields are under a different name than their constant name.

This hasn't been an issue so far because Forge deobfuscates the game at runtime, but Fabric does not, so a call to `Operation.ADDITION` ends up actually being compiled as `class_1323.field_6328`, but obviously we want people to be able to use the constant name, instead of having to do `Operation.field_6328`