### PR TITLE
Ignore bridge methods when checking if a method is overriden (Fixes Covariant Return Types)

### DIFF
--- a/JavaIntegration/src/main/java/org/openzen/zencode/java/module/converters/JavaNativeClassConverter.java
+++ b/JavaIntegration/src/main/java/org/openzen/zencode/java/module/converters/JavaNativeClassConverter.java
@@ -305,7 +305,7 @@ public class JavaNativeClassConverter {
 	}
 
 	private boolean isOverridden(Class<?> cls, Method method) {
-		return !method.getDeclaringClass().equals(cls);
+		return !method.getDeclaringClass().equals(cls) || method.isBridge();
 	}
 
 	private void fillConstructor(Class<?> cls, HighLevelDefinition definition, JavaClass javaClass, boolean foundRegistry) {


### PR DESCRIPTION
Fixes
```java
public interface ITagManager<T extends MCTag>{
  
  T tag(ResourceLocation loc);
  T tag(String loc);
}

public class KnownTagManager<T> implements ITagManager<KnownTag<T>> {
  KnownTag<T> tag(ResourceLocation loc);
  KnownTag<T> tag(String loc);
}
```
returning `MCTag` instead of `KnownTag<T>`