### PR TITLE
Fix: Having an explicit and an implicit match is no ambiguous match

### DIFF
--- a/CodeModel/src/main/java/org/openzen/zenscript/codemodel/compilation/MatchedCallArguments.java
+++ b/CodeModel/src/main/java/org/openzen/zenscript/codemodel/compilation/MatchedCallArguments.java
@@ -49,7 +49,7 @@ public class MatchedCallArguments<T extends AnyMethod> {
 					if (result == null) {
 						result = new MatchedCallArguments<>(method, matched);
 						implicit = true;
-					} else {
+					} else if (implicit) {
 						ambiguous = true;
 					}
 					candidates.add(method.getHeader());


### PR DESCRIPTION
Currently, if there are 2 matching methods, one matching exact and one implicit there are 2 scenarios:
- The implicit one is checked first -> all okay
- The explicit one is checked first -> ambiguous method call

This PR fixes that.


💭 Discussion:  
Alternative way of implementing the matching logic would be to group by match level first.  
What do we prefer?
```java
	private static final CastedExpression.Level[] candidateLevelsInOrderOfPriority = {CastedExpression.Level.EXACT, CastedExpression.Level.IMPLICIT};

	public static <T extends AnyMethod> MatchedCallArguments<T> match(
			ExpressionCompiler compiler,
			CodePosition position,
			List<T> overloads,
			TypeID asType,
			TypeID[] typeArguments,
			CompilingExpression... arguments
	) {

		final Map<CastedExpression.Level, List<MatchedCallArguments<T>>> methodsGroupedByMatchLevel = overloads.stream()
				.map(method -> new MatchedCallArguments<>(method, match(compiler, position, method, asType, typeArguments, arguments)))
				.collect(Collectors.groupingBy(matched -> matched.arguments.level, Collectors.toList()));


		for (final CastedExpression.Level level : candidateLevelsInOrderOfPriority) {
			final List<MatchedCallArguments<T>> matchingMethods = methodsGroupedByMatchLevel.getOrDefault(level, Collections.emptyList());

			switch (matchingMethods.size()) {
				case 0: continue;
				case 1: return matchingMethods.get(0);
				default: return ambiguousCall(methodsGroupedByMatchLevel);
			}
		}

		return new MatchedCallArguments<>(CompileErrors.noMethodMatched(overloads.stream()
				.map(AnyMethod::getHeader)
				.collect(Collectors.toList())));
	}

	private static <T extends AnyMethod> MatchedCallArguments<T> ambiguousCall(Map<CastedExpression.Level, List<MatchedCallArguments<T>>> methodsGroupedByMatchLevel) {
		List<FunctionHeader> candidates = Arrays.stream(candidateLevelsInOrderOfPriority)
				.flatMap(level -> methodsGroupedByMatchLevel.getOrDefault(level, Collections.emptyList()).stream())
				.map(pair -> pair.method.getHeader())
				.collect(Collectors.toList());

		return new MatchedCallArguments<>(CompileErrors.ambiguousCall(candidates));
	}
```